### PR TITLE
Added support for spanish special chars

### DIFF
--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -343,7 +343,7 @@ class Template
     private function variables(Context $context, $current, $escaped)
     {
         $name = $current[Tokenizer::NAME];
-        $value = $context->get($name);
+        $value = utf8_encode($context->get($name));
         if ($name == '@index') {
             return $context->lastIndex();
         }


### PR DESCRIPTION
Hi,

I was testing Handlebars PHP with this template:

![handlebars0](https://cloud.githubusercontent.com/assets/4080656/8021179/b40c2c98-0c5a-11e5-97db-796c3014aa3c.png)

But, the template wasn't working with spanish accents: (chars like í ñ) and the Template was showing a blank text.

![handlebars1](https://cloud.githubusercontent.com/assets/4080656/8021180/b40c746e-0c5a-11e5-8389-41de357b3ae6.png)

So, the present solution adds support applying the utf8_encode and saving the text of blank issue:

![handlebars2](https://cloud.githubusercontent.com/assets/4080656/8021181/b40e84ac-0c5a-11e5-8bf1-5ca0e08dd16d.png)

Regards,
