### PR TITLE
added support for phpv7

### DIFF
--- a/src/Handlebars/HandlebarsString.php
+++ b/src/Handlebars/HandlebarsString.php
@@ -16,7 +16,7 @@
 
 namespace Handlebars;
 
-class String
+class HandlebarsString
 {
     private $string = "";
 

--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -561,7 +561,7 @@ class Helpers
         $limit = $m[2];
         $ellipsis = $m[3];
         $value = substr($context->get($keyname), 0, $limit);
-        if ($ellipsis) {
+        if ($ellipsis && strlen($context->get($keyname)) > $limit) {
             $value .= $ellipsis;
         }
         return $value;

--- a/src/Handlebars/Loader/FilesystemLoader.php
+++ b/src/Handlebars/Loader/FilesystemLoader.php
@@ -15,7 +15,7 @@
 
 namespace Handlebars\Loader;
 use Handlebars\Loader;
-use Handlebars\String;
+use Handlebars\HandlebarsString;
 
 
 class FilesystemLoader implements Loader
@@ -78,7 +78,7 @@ class FilesystemLoader implements Loader
      *
      * @param string $name template name
      *
-     * @return String Handlebars Template source
+     * @return HandlebarsString Handlebars Template source
      */
     public function load($name)
     {
@@ -86,7 +86,7 @@ class FilesystemLoader implements Loader
             $this->_templates[$name] = $this->loadFile($name);
         }
 
-        return new String($this->_templates[$name]);
+        return new HandlebarsString($this->_templates[$name]);
     }
 
     /**

--- a/src/Handlebars/Loader/StringLoader.php
+++ b/src/Handlebars/Loader/StringLoader.php
@@ -16,7 +16,7 @@
 
 namespace Handlebars\Loader;
 use Handlebars\Loader;
-use Handlebars\String;
+use Handlebars\HandlebarsString;
 
 class StringLoader implements Loader
 {
@@ -26,11 +26,11 @@ class StringLoader implements Loader
      *
      * @param string $name Handlebars Template source
      *
-     * @return String Handlebars Template source
+     * @return HandlebarsString Handlebars Template source
      */
     public function load($name)
     {
-        return new String($name);
+        return new HandlebarsString($name);
     }
 
 }

--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -92,7 +92,7 @@ class Tokenizer
      */
     public function scan($text, $delimiters = null)
     {
-        if ($text instanceof String) {
+        if ($text instanceof HandlebarsString) {
             $text = $text->getString();
         }
         $this->reset();


### PR DESCRIPTION
- renamed class String to HandlebarsString due to the fact that the class String cant be used in phpv7
