### PR TITLE
Tokenizer::scan performance improvements

### DIFF
--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -82,144 +82,144 @@ class Tokenizer
     protected $otag;
     protected $ctag;
 
-	/**
-	 * Scan and tokenize template source.
-	 *
-	 * @param string $text       Mustache template source to tokenize
-	 * @param string $delimiters Optional, pass opening and closing delimiters
-	 *
-	 * @return array Set of Mustache tokens
-	 */
-	public function scan($text, $delimiters = null)
-	{
-		if ($text instanceof HandlebarsString) {
-			$text = $text->getString();
-		}
+    /**
+     * Scan and tokenize template source.
+     *
+     * @param string $text       Mustache template source to tokenize
+     * @param string $delimiters Optional, pass opening and closing delimiters
+     *
+     * @return array Set of Mustache tokens
+     */
+    public function scan($text, $delimiters = null)
+    {
+        if ($text instanceof HandlebarsString) {
+            $text = $text->getString();
+        }
 
-		$this->reset();
+        $this->reset();
 
-		if ($delimiters = trim($delimiters)) {
-			list($otag, $ctag) = explode(' ', $delimiters);
-			$this->otag = $otag;
-			$this->ctag = $ctag;
-		}
+        if ($delimiters = trim($delimiters)) {
+            list($otag, $ctag) = explode(' ', $delimiters);
+            $this->otag = $otag;
+            $this->ctag = $ctag;
+        }
 
-		$openingTagLength = strlen($this->otag);
-		$closingTagLength = strlen($this->ctag);
-		$firstOpeningTagCharacter = $this->otag[0];
-		$firstClosingTagCharacter = $this->ctag[0];
+        $openingTagLength = strlen($this->otag);
+        $closingTagLength = strlen($this->ctag);
+        $firstOpeningTagCharacter = $this->otag[0];
+        $firstClosingTagCharacter = $this->ctag[0];
 
-		$len = strlen($text);
+        $len = strlen($text);
 
-		for ($i = 0; $i < $len; $i++) {
+        for ($i = 0; $i < $len; $i++) {
 
-			$character = $text[$i];
+            $character = $text[$i];
 
-			switch ($this->state) {
+            switch ($this->state) {
 
-				case self::IN_TEXT:
-					if ($character === $firstOpeningTagCharacter && $this->tagChange($this->otag, $text, $i, $openingTagLength)
-					) {
-						$i--;
-						$this->flushBuffer();
-						$this->state = self::IN_TAG_TYPE;
-					} else {
-						if ($character == "\n") {
-							$this->filterLine();
-						} else {
-							$this->buffer .= $character;
-						}
-					}
-					break;
+                case self::IN_TEXT:
+                    if ($character === $firstOpeningTagCharacter && $this->tagChange($this->otag, $text, $i, $openingTagLength)
+                    ) {
+                        $i--;
+                        $this->flushBuffer();
+                        $this->state = self::IN_TAG_TYPE;
+                    } else {
+                        if ($character == "\n") {
+                            $this->filterLine();
+                        } else {
+                            $this->buffer .= $character;
+                        }
+                    }
+                    break;
 
-				case self::IN_TAG_TYPE:
+                case self::IN_TAG_TYPE:
 
-					$i += $openingTagLength - 1;
-					if (isset($this->tagTypes[$text[$i + 1]])) {
-						$tag = $text[$i + 1];
-						$this->tagType = $tag;
-					} else {
-						$tag = null;
-						$this->tagType = self::T_ESCAPED;
-					}
+                    $i += $openingTagLength - 1;
+                    if (isset($this->tagTypes[$text[$i + 1]])) {
+                        $tag = $text[$i + 1];
+                        $this->tagType = $tag;
+                    } else {
+                        $tag = null;
+                        $this->tagType = self::T_ESCAPED;
+                    }
 
-					if ($this->tagType === self::T_DELIM_CHANGE) {
-						$i = $this->changeDelimiters($text, $i);
-						$openingTagLength = strlen($this->otag);
-						$closingTagLength = strlen($this->ctag);
-						$firstOpeningTagCharacter = $this->otag[0];
-						$firstClosingTagCharacter = $this->ctag[0];
+                    if ($this->tagType === self::T_DELIM_CHANGE) {
+                        $i = $this->changeDelimiters($text, $i);
+                        $openingTagLength = strlen($this->otag);
+                        $closingTagLength = strlen($this->ctag);
+                        $firstOpeningTagCharacter = $this->otag[0];
+                        $firstClosingTagCharacter = $this->ctag[0];
 
-						$this->state = self::IN_TEXT;
-					} else {
-						if ($tag !== null) {
-							$i++;
-						}
-						$this->state = self::IN_TAG;
-					}
-					$this->seenTag = $i;
-					break;
+                        $this->state = self::IN_TEXT;
+                    } else {
+                        if ($tag !== null) {
+                            $i++;
+                        }
+                        $this->state = self::IN_TAG;
+                    }
+                    $this->seenTag = $i;
+                    break;
 
-				default:
-					if ($character === $firstClosingTagCharacter && $this->tagChange($this->ctag, $text, $i, $closingTagLength)) {
-						// Sections (Helpers) can accept parameters
-						// Same thing for Partials (little known fact)
-						if (in_array($this->tagType, [
-								self::T_SECTION,
-								self::T_PARTIAL,
-								self::T_PARTIAL_2]
-						)) {
-							$newBuffer = explode(' ', trim($this->buffer), 2);
-							$args = '';
-							if (count($newBuffer) == 2) {
-								$args = $newBuffer[1];
-							}
-							$this->buffer = $newBuffer[0];
-						}
-						$t = [
-							self::TYPE => $this->tagType,
-							self::NAME => trim($this->buffer),
-							self::OTAG => $this->otag,
-							self::CTAG => $this->ctag,
-							self::INDEX => ($this->tagType == self::T_END_SECTION) ?
-								$this->seenTag - $openingTagLength :
-								$i + strlen($this->ctag),
-						];
-						if (isset($args)) {
-							$t[self::ARGS] = $args;
-						}
-						$this->tokens[] = $t;
-						unset($t);
-						unset($args);
-						$this->buffer = '';
-						$i += strlen($this->ctag) - 1;
-						$this->state = self::IN_TEXT;
-						if ($this->tagType == self::T_UNESCAPED) {
-							if ($this->ctag == '}}') {
-								$i++;
-							} else {
-								// Clean up `{{{ tripleStache }}}` style tokens.
-								$lastIndex = count($this->tokens) - 1;
-								$lastName = $this->tokens[$lastIndex][self::NAME];
-								if (substr($lastName, -1) === '}') {
-									$this->tokens[$lastIndex][self::NAME] = trim(
-										substr($lastName, 0, -1)
-									);
-								}
-							}
-						}
-					} else {
-						$this->buffer .= $character;
-					}
-					break;
-			}
+                default:
+                    if ($character === $firstClosingTagCharacter && $this->tagChange($this->ctag, $text, $i, $closingTagLength)) {
+                        // Sections (Helpers) can accept parameters
+                        // Same thing for Partials (little known fact)
+                        if (in_array($this->tagType, [
+                                self::T_SECTION,
+                                self::T_PARTIAL,
+                                self::T_PARTIAL_2]
+                        )) {
+                            $newBuffer = explode(' ', trim($this->buffer), 2);
+                            $args = '';
+                            if (count($newBuffer) == 2) {
+                                $args = $newBuffer[1];
+                            }
+                            $this->buffer = $newBuffer[0];
+                        }
+                        $t = [
+                            self::TYPE => $this->tagType,
+                            self::NAME => trim($this->buffer),
+                            self::OTAG => $this->otag,
+                            self::CTAG => $this->ctag,
+                            self::INDEX => ($this->tagType == self::T_END_SECTION) ?
+                                $this->seenTag - $openingTagLength :
+                                $i + strlen($this->ctag),
+                        ];
+                        if (isset($args)) {
+                            $t[self::ARGS] = $args;
+                        }
+                        $this->tokens[] = $t;
+                        unset($t);
+                        unset($args);
+                        $this->buffer = '';
+                        $i += strlen($this->ctag) - 1;
+                        $this->state = self::IN_TEXT;
+                        if ($this->tagType == self::T_UNESCAPED) {
+                            if ($this->ctag == '}}') {
+                                $i++;
+                            } else {
+                                // Clean up `{{{ tripleStache }}}` style tokens.
+                                $lastIndex = count($this->tokens) - 1;
+                                $lastName = $this->tokens[$lastIndex][self::NAME];
+                                if (substr($lastName, -1) === '}') {
+                                    $this->tokens[$lastIndex][self::NAME] = trim(
+                                        substr($lastName, 0, -1)
+                                    );
+                                }
+                            }
+                        }
+                    } else {
+                        $this->buffer .= $character;
+                    }
+                    break;
+            }
 
-		}
+        }
 
-		$this->filterLine(true);
+        $this->filterLine(true);
 
-		return $this->tokens;
-	}
+        return $this->tokens;
+    }
 
     /**
      * Helper function to reset tokenizer internal state.
@@ -335,19 +335,19 @@ class Tokenizer
         return $closeIndex + strlen($close) - 1;
     }
 
-	/**
-	 * Test whether it's time to change tags.
-	 *
-	 * @param string $tag Current tag name
-	 * @param string $text Mustache template source
-	 * @param int $index Current tokenizer index
-	 * @param int $tagLength Length of the opening/closing tag string
-	 *
-	 * @return boolean True if this is a closing section tag
-	 */
-	protected function tagChange($tag, $text, $index, $tagLength)
-	{
-		return substr($text, $index, $tagLength) === $tag;
-	}
+    /**
+     * Test whether it's time to change tags.
+     *
+     * @param string $tag Current tag name
+     * @param string $text Mustache template source
+     * @param int $index Current tokenizer index
+     * @param int $tagLength Length of the opening/closing tag string
+     *
+     * @return boolean True if this is a closing section tag
+     */
+    protected function tagChange($tag, $text, $index, $tagLength)
+    {
+        return substr($text, $index, $tagLength) === $tag;
+    }
 
 }

--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -82,126 +82,144 @@ class Tokenizer
     protected $otag;
     protected $ctag;
 
-    /**
-     * Scan and tokenize template source.
-     *
-     * @param string $text       Mustache template source to tokenize
-     * @param string $delimiters Optional, pass opening and closing delimiters
-     *
-     * @return array Set of Mustache tokens
-     */
-    public function scan($text, $delimiters = null)
-    {
-        if ($text instanceof HandlebarsString) {
-            $text = $text->getString();
-        }
-        $this->reset();
+	/**
+	 * Scan and tokenize template source.
+	 *
+	 * @param string $text       Mustache template source to tokenize
+	 * @param string $delimiters Optional, pass opening and closing delimiters
+	 *
+	 * @return array Set of Mustache tokens
+	 */
+	public function scan($text, $delimiters = null)
+	{
+		if ($text instanceof HandlebarsString) {
+			$text = $text->getString();
+		}
 
-        if ($delimiters = trim($delimiters)) {
-            list($otag, $ctag) = explode(' ', $delimiters);
-            $this->otag = $otag;
-            $this->ctag = $ctag;
-        }
+		$this->reset();
 
-        $len = strlen($text);
-        for ($i = 0; $i < $len; $i++) {
-            switch ($this->state) {
-            case self::IN_TEXT:
-                if ($this->tagChange($this->otag, $text, $i)) {
-                    $i--;
-                    $this->flushBuffer();
-                    $this->state = self::IN_TAG_TYPE;
-                } else {
-                    if ($text[$i] == "\n") {
-                        $this->filterLine();
-                    } else {
-                        $this->buffer .= $text[$i];
-                    }
-                }
-                break;
+		if ($delimiters = trim($delimiters)) {
+			list($otag, $ctag) = explode(' ', $delimiters);
+			$this->otag = $otag;
+			$this->ctag = $ctag;
+		}
 
-            case self::IN_TAG_TYPE:
+		$openingTagLength = strlen($this->otag);
+		$closingTagLength = strlen($this->ctag);
+		$firstOpeningTagCharacter = $this->otag[0];
+		$firstClosingTagCharacter = $this->ctag[0];
 
-                $i += strlen($this->otag) - 1;
-                if (isset($this->tagTypes[$text[$i + 1]])) {
-                    $tag = $text[$i + 1];
-                    $this->tagType = $tag;
-                } else {
-                    $tag = null;
-                    $this->tagType = self::T_ESCAPED;
-                }
+		$len = strlen($text);
 
-                if ($this->tagType === self::T_DELIM_CHANGE) {
-                    $i = $this->changeDelimiters($text, $i);
-                    $this->state = self::IN_TEXT;
-                } else {
-                    if ($tag !== null) {
-                        $i++;
-                    }
-                    $this->state = self::IN_TAG;
-                }
-                $this->seenTag = $i;
-                break;
+		for ($i = 0; $i < $len; $i++) {
 
-            default:
-                if ($this->tagChange($this->ctag, $text, $i)) {
-                    // Sections (Helpers) can accept parameters
-                    // Same thing for Partials (little known fact)
-                    if (in_array($this->tagType, [
-                                    self::T_SECTION,
-                                    self::T_PARTIAL,
-                                    self::T_PARTIAL_2]
-                            )) {
-                        $newBuffer = explode(' ', trim($this->buffer), 2);
-                        $args = '';
-                        if (count($newBuffer) == 2) {
-                            $args = $newBuffer[1];
-                        }
-                        $this->buffer = $newBuffer[0];
-                    }
-                    $t = [
-                        self::TYPE => $this->tagType,
-                        self::NAME => trim($this->buffer),
-                        self::OTAG => $this->otag,
-                        self::CTAG => $this->ctag,
-                        self::INDEX => ($this->tagType == self::T_END_SECTION) ?
-                            $this->seenTag - strlen($this->otag) :
-                            $i + strlen($this->ctag),
-                    ];
-                    if (isset($args)) {
-                        $t[self::ARGS] = $args;
-                    }
-                    $this->tokens[] = $t;
-                    unset($t);
-                    unset($args);
-                    $this->buffer = '';
-                    $i += strlen($this->ctag) - 1;
-                    $this->state = self::IN_TEXT;
-                    if ($this->tagType == self::T_UNESCAPED) {
-                        if ($this->ctag == '}}') {
-                            $i++;
-                        } else {
-                            // Clean up `{{{ tripleStache }}}` style tokens.
-                            $lastIndex = count($this->tokens) - 1;
-                            $lastName = $this->tokens[$lastIndex][self::NAME];
-                            if (substr($lastName, -1) === '}') {
-                                $this->tokens[$lastIndex][self::NAME] = trim(
-                                    substr($lastName, 0, -1)
-                                );
-                            }
-                        }
-                    }
-                } else {
-                    $this->buffer .= $text[$i];
-                }
-                break;
-            }
-        }
+			$character = $text[$i];
 
-        $this->filterLine(true);
+			switch ($this->state) {
 
-        return $this->tokens;
-    }
+				case self::IN_TEXT:
+					if ($character === $firstOpeningTagCharacter && $this->tagChange($this->otag, $text, $i, $openingTagLength)
+					) {
+						$i--;
+						$this->flushBuffer();
+						$this->state = self::IN_TAG_TYPE;
+					} else {
+						if ($character == "\n") {
+							$this->filterLine();
+						} else {
+							$this->buffer .= $character;
+						}
+					}
+					break;
+
+				case self::IN_TAG_TYPE:
+
+					$i += $openingTagLength - 1;
+					if (isset($this->tagTypes[$text[$i + 1]])) {
+						$tag = $text[$i + 1];
+						$this->tagType = $tag;
+					} else {
+						$tag = null;
+						$this->tagType = self::T_ESCAPED;
+					}
+
+					if ($this->tagType === self::T_DELIM_CHANGE) {
+						$i = $this->changeDelimiters($text, $i);
+						$openingTagLength = strlen($this->otag);
+						$closingTagLength = strlen($this->ctag);
+						$firstOpeningTagCharacter = $this->otag[0];
+						$firstClosingTagCharacter = $this->ctag[0];
+
+						$this->state = self::IN_TEXT;
+					} else {
+						if ($tag !== null) {
+							$i++;
+						}
+						$this->state = self::IN_TAG;
+					}
+					$this->seenTag = $i;
+					break;
+
+				default:
+					if ($character === $firstClosingTagCharacter && $this->tagChange($this->ctag, $text, $i, $closingTagLength)) {
+						// Sections (Helpers) can accept parameters
+						// Same thing for Partials (little known fact)
+						if (in_array($this->tagType, [
+								self::T_SECTION,
+								self::T_PARTIAL,
+								self::T_PARTIAL_2]
+						)) {
+							$newBuffer = explode(' ', trim($this->buffer), 2);
+							$args = '';
+							if (count($newBuffer) == 2) {
+								$args = $newBuffer[1];
+							}
+							$this->buffer = $newBuffer[0];
+						}
+						$t = [
+							self::TYPE => $this->tagType,
+							self::NAME => trim($this->buffer),
+							self::OTAG => $this->otag,
+							self::CTAG => $this->ctag,
+							self::INDEX => ($this->tagType == self::T_END_SECTION) ?
+								$this->seenTag - $openingTagLength :
+								$i + strlen($this->ctag),
+						];
+						if (isset($args)) {
+							$t[self::ARGS] = $args;
+						}
+						$this->tokens[] = $t;
+						unset($t);
+						unset($args);
+						$this->buffer = '';
+						$i += strlen($this->ctag) - 1;
+						$this->state = self::IN_TEXT;
+						if ($this->tagType == self::T_UNESCAPED) {
+							if ($this->ctag == '}}') {
+								$i++;
+							} else {
+								// Clean up `{{{ tripleStache }}}` style tokens.
+								$lastIndex = count($this->tokens) - 1;
+								$lastName = $this->tokens[$lastIndex][self::NAME];
+								if (substr($lastName, -1) === '}') {
+									$this->tokens[$lastIndex][self::NAME] = trim(
+										substr($lastName, 0, -1)
+									);
+								}
+							}
+						}
+					} else {
+						$this->buffer .= $character;
+					}
+					break;
+			}
+
+		}
+
+		$this->filterLine(true);
+
+		return $this->tokens;
+	}
 
     /**
      * Helper function to reset tokenizer internal state.
@@ -317,18 +335,19 @@ class Tokenizer
         return $closeIndex + strlen($close) - 1;
     }
 
-    /**
-     * Test whether it's time to change tags.
-     *
-     * @param string $tag   Current tag name
-     * @param string $text  Mustache template source
-     * @param int    $index Current tokenizer index
-     *
-     * @return boolean True if this is a closing section tag
-     */
-    protected function tagChange($tag, $text, $index)
-    {
-        return substr($text, $index, strlen($tag)) === $tag;
-    }
+	/**
+	 * Test whether it's time to change tags.
+	 *
+	 * @param string $tag Current tag name
+	 * @param string $text Mustache template source
+	 * @param int $index Current tokenizer index
+	 * @param int $tagLength Length of the opening/closing tag string
+	 *
+	 * @return boolean True if this is a closing section tag
+	 */
+	protected function tagChange($tag, $text, $index, $tagLength)
+	{
+		return substr($text, $index, $tagLength) === $tag;
+	}
 
 }


### PR DESCRIPTION
This PR provides a 77.6% reduction in wall time of the Tokenizer::scan method and outlines each of the changes. The profile below shows the overall difference before and after the changes to the Tokenizer::scan method. Profilers were generated based on an execution count of 10,000 and a Handlebars string of 5KB.

<img width="666" alt="profile1" src="https://user-images.githubusercontent.com/44622117/61014270-a1e17b00-a354-11e9-93e6-10c55b7ab3ec.png">

1: The majority of the wall time was spent in trying to detect a tag change. The internals of this method use an index to get the get a pair of characters out of the entire message to determine whether it is an opening or closing tag. Evaluating a large message this way was the main culprit of the runtime bottleneck. To avoid checking characters that we not an opening or closing tag, the first change was putting a check for an opening or closing character before executing the tagChange method. This change cut down a majority of the wall time from 144 seconds to 35 seconds given a 10,000 execution count cycle:

2: The second change was made to limit computing the length of the opening and closing tag length which avoids unnecessarily recalculating every time the tag change method was executed. This optimization brought the wall time down 1.3 seconds given a 10,000 execution count cycle.

3: The third change was to replace string lookups by index with references. The first update was to create a reference to the character in evaluation iteration and replace the text lookup by index with the reference. The second update was to create a reference for the first character in the opening and closing tag to avoid a lookup by index in the references created in the first optimization. This optimization brought the wall time down 1.4 seconds given a 10,000 execution count cycle.

Handlebars message utilized:
```
{{Recipient.FirstName}},

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nulla sem, tristique eu nisi sagittis, sodales pulvinar est. Suspendisse purus diam, dapibus vitae suscipit nec, volutpat non est. Sed eget magna a justo pellentesque volutpat vitae id ex. Sed ultricies risus sed vehicula egestas. Ut placerat tellus id vestibulum convallis. Vivamus vel metus vitae sapien fermentum mollis. Phasellus vehicula tortor eu nulla fermentum maximus.


{{Unsubscribe}}

{{{Organization.Address}}}
```

Happy to contribute some performance tests as well if necessary.

